### PR TITLE
Setting default comparator for namespace_map to be the expected behaviour.

### DIFF
--- a/include/quicr/namespace.h
+++ b/include/quicr/namespace.h
@@ -224,12 +224,28 @@ class namespace_comparator : Comp<quicr::Namespace>
 
 /**
  * @brief A map keyed on quicr::Namespace.
+ *
+ * A map keyed by quicr::Namespace, and searchable by quicr::Name as well. It
+ * is thus possible to use a quicr::Name to retrieve an entry.
+ *
+ * When indexing using quicr::Name, if the given comparator is std::greater,
+ * the entry returned is that which has a key (quicr::Namespace) whose value
+ * matches quicr::Name the longest (i.e. most specific namespace). When the
+ * comparator is std::less, the entry returned is that which has a key
+ * (quicr::Namespace) whose value matches quicr::Name the shortest (i.e. the
+ * shortest match)
+ *
  * @tparam T The value type
- * @tparam Comparator The STL comparator to use inside the namespace_comparator. Defaults to std::less<T>.
- * @tparam Allocator The allocator type to use. Defaults to the same as std::map.
+ * @tparam Comparator The STL comparator to use inside the namespace_comparator. Defaults to std::greater<T>.
+ * @tparam Allocator The allocator type to use. Default is same as std::map.
  */
 template<class T,
-         template<typename> class Comparator = std::less,
+         template<typename> class Comparator = std::greater,
          class Allocator = std::allocator<std::pair<const quicr::Namespace, T>>>
-using namespace_map = std::map<quicr::Namespace, T, namespace_comparator<Comparator>, Allocator>;
+class namespace_map : public std::map<quicr::Namespace, T, namespace_comparator<Comparator>, Allocator>
+{
+    using base_t = std::map<quicr::Namespace, T, namespace_comparator<Comparator>, Allocator>;
+public:
+    using base_t::base_t;
+};
 } // namespace quicr

--- a/test/namespace.cpp
+++ b/test/namespace.cpp
@@ -63,28 +63,41 @@ TEST_CASE("quicr::Namespace String Constructor Test")
 TEST_CASE("quicr::Namespace Map Sorting Test")
 {
     quicr::Name name = 0xABCDEFFFFFFFFFFFFFFFFFFFFFFFFFFF_name;
-    quicr::Namespace ns(name, 24);
-    quicr::Namespace ns2(name, 16);
-    {
-        quicr::namespace_map<int> ns_map{ { ns, 101 }, { ns2, 102 } };
+    quicr::Namespace base_namespace(name, 16);
+    quicr::Namespace sub_namespace(name, 24);
 
-        CHECK_EQ(ns_map.count(ns), 1);
-        CHECK_EQ(ns_map.count(ns2), 1);
+    const int base_value = 101;
+    const int sub_value = 102;
+
+    // Find returns the smallest match.
+    {
+        quicr::namespace_map<int, std::less> ns_map{
+            { base_namespace, base_value },
+            { sub_namespace, sub_value },
+        };
+
+        CHECK_EQ(ns_map.count(sub_namespace), 1);
+        CHECK_EQ(ns_map.count(base_namespace), 1);
         CHECK_EQ(ns_map.size(), 2);
         CHECK_EQ(ns_map.count(name), 2);
-        CHECK_EQ(ns_map.find(ns)->second, 101);
-        CHECK_EQ(ns_map.find(ns2)->second, 102);
-        CHECK_EQ(ns_map.find(name)->second, 102);
+        CHECK_EQ(ns_map.find(sub_namespace)->second, sub_value);
+        CHECK_EQ(ns_map.find(base_namespace)->second, base_value);
+        CHECK_EQ(ns_map.find(name)->second, base_value);
     }
-    {
-        quicr::namespace_map<int, std::greater> ns_map{ { ns, 101 }, { ns2, 102 } };
 
-        CHECK_EQ(ns_map.count(ns), 1);
-        CHECK_EQ(ns_map.count(ns2), 1);
+    // Find returns the greatest match.
+    {
+        quicr::namespace_map<int, std::greater> ns_map{
+            { base_namespace, base_value },
+            { sub_namespace, sub_value },
+        };
+
+        CHECK_EQ(ns_map.count(sub_namespace), 1);
+        CHECK_EQ(ns_map.count(base_namespace), 1);
         CHECK_EQ(ns_map.size(), 2);
         CHECK_EQ(ns_map.count(name), 2);
-        CHECK_EQ(ns_map.find(ns)->second, 101);
-        CHECK_EQ(ns_map.find(ns2)->second, 102);
-        CHECK_EQ(ns_map.find(name)->second, 101);
+        CHECK_EQ(ns_map.find(sub_namespace)->second, sub_value);
+        CHECK_EQ(ns_map.find(base_namespace)->second, base_value);
+        CHECK_EQ(ns_map.find(name)->second, sub_value);
     }
 }


### PR DESCRIPTION
Very interesting stuff this comparator, learning new stuff all the time. The test looks like a lot has changed, but hilariously, it was working exactly as intended. The changes to the test are just general cleanup, they *do NOT* change it's behaviour at all.

The big change here is that the default comparator for `quicr::namespace_map` is now `std::greater` instead of `std::less`. The reason for this is simple: My original assumption about what was being found was wrong. The real behaviour:

- When sorting with `std::less`, when using a `quicr::Name` to index it, the *shortest* match will be returned.
- When sorting with `std::greater`, when using a `quicr::Name` to index it, the *longest* match will be returned.

For whatever reason, I seemed to have this reversed in my head, and yet still wrote the correct test that showed that exact result. I suppose the way the test was written before was vague and unhelpful. So, the cleanup of the test and some added comments to the type itself should clear up the issue.

Also changed, but not really important: `quicr::namespace_map` is now a concrete type inheriting from `std::map`, instead of just being an alias.